### PR TITLE
Added Data Science Dojo

### DIFF
--- a/data_science_bootcamps.csv
+++ b/data_science_bootcamps.csv
@@ -1,4 +1,5 @@
 BOOTCAMP,URL,PROGRAM,COUNTRY,STATE,PRICE,ONLINE,COMMENTS
+Data Science Dojo,http://datasciencedojo.com/bootcamp/,Data Science and Data Engineering Bootcamp,US and others,,2999,F,"5-day immersive data science bootcamp, no pre-requisites"
 The Dev Masters, http://www.thedevmasters.com, Data Science,US,CA,2995,F,6 Days Program
 Zipfian Academy,http://www.zipfianacademy.com/programs/#datascienceprogram,Data Science Immersive,US,CA,16000,F,12 week program
 Zipfian Academy,http://www.zipfianacademy.com/programs/#dataengprogram,Data Engineering Immersive,US,CA,16000,F,12 week program


### PR DESCRIPTION
Data Science Dojo offers short-duration, in-person, hands-on training to get started with practical data science in just one week.